### PR TITLE
 SUB3-HYUNJAE 1차 개인 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,42 @@
+import { RouterProvider } from 'react-router';
+import { createBrowserRouter } from 'react-router-dom';
 import React from 'react';
+import Issues from './pages/issues';
+import GlobalStyle from './styles/GlobalStyle';
+import Error from './pages/error';
+import Issue from './pages/issue';
+import HttpResultStateProvider from './store/httpResultContext';
+import ReposContextProvider from './store/reposContext';
+import Header from './components/Header';
+import IssueContextProvider from './store/issueContext';
 
-const App = () => {};
+const router = createBrowserRouter([
+  {
+    path: '/',
+    element: <Issues />,
+  },
+  {
+    path: '/:number',
+    element: <Issue />,
+  },
+  {
+    path: '/error',
+    element: <Error />,
+  },
+]);
+
+const App = () => (
+  <>
+    <GlobalStyle />
+    <HttpResultStateProvider>
+      <ReposContextProvider>
+        <IssueContextProvider>
+          <Header />
+          <RouterProvider router={router}></RouterProvider>
+        </IssueContextProvider>
+      </ReposContextProvider>
+    </HttpResultStateProvider>
+  </>
+);
 
 export default App;

--- a/src/apis/config.js
+++ b/src/apis/config.js
@@ -1,0 +1,12 @@
+import axios from 'axios';
+import { BASE_URL, ACESS_TOKEN } from '../constants';
+
+const axiosInstance = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${ACESS_TOKEN}`,
+    'X-GitHub-Api-Version': '2022-11-28',
+  },
+});
+export default axiosInstance;

--- a/src/apis/issues.js
+++ b/src/apis/issues.js
@@ -1,0 +1,52 @@
+import dateFormat from '../utils/dateFormat';
+import handleErrorResult from '../utils/handleErrorResult';
+import axiosInstance from './config';
+
+const fetchIssues = async ({ page }) => {
+  try {
+    const { data } = await axiosInstance.get(`repos/facebook/react/issues?page=${page}&sort=comments&direction=desc`);
+
+    const issues = processedData(data, 'array');
+    return { issues };
+  } catch (e) {
+    return handleErrorResult(e);
+  }
+};
+
+const fetchIssue = async issueNumber => {
+  try {
+    const { data } = await axiosInstance.get(`repos/facebook/react/issues/${issueNumber}`);
+    const issue = processedData(data, 'object');
+    return { issue };
+  } catch (e) {
+    return handleErrorResult(e);
+  }
+};
+
+const processedData = (data, dataType) => {
+  let processedData;
+  if (dataType === 'array') {
+    processedData = data.map(({ number, title, user, created_at: createdAt, comments: commentCount }) => ({
+      number,
+      title,
+      login: user.login,
+      createdAt: dateFormat(createdAt),
+      commentCount,
+    }));
+  } else {
+    const { title, user, created_at: createdAt, comments: commentCount, body } = data;
+
+    processedData = {
+      title,
+      login: user.login,
+      createdAt: dateFormat(createdAt),
+      commentCount,
+      profileImageUrl: user.avatar_url,
+      body,
+    };
+  }
+
+  return processedData;
+};
+
+export { fetchIssues, fetchIssue };

--- a/src/components/Ad.jsx
+++ b/src/components/Ad.jsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+
+const StyledAd = styled.img`
+  width: 30%;
+  height: auto;
+`;
+
+const Container = styled.div`
+  width: 100%;
+  margin: 20px 0;
+  text-align: center;
+  cursor: pointer;
+  background-color: #f0f0f0;
+`;
+
+const Ad = ({ link, imageUrl }) => (
+  <Container onClick={() => window.location.href(link)}>
+    <StyledAd alt="ad" src={imageUrl} />
+  </Container>
+);
+
+export default Ad;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+import { useContext } from 'react';
+import { ReposContext } from '../store/reposContext';
+
+const StyledHeader = styled.header`
+  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 50px;
+  display: flex;
+  -webkit-box-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  align-items: center;
+  background-color: rgb(237, 237, 237);
+`;
+
+const Header = () => {
+  const { organization, repos } = useContext(ReposContext);
+
+  return (
+    <StyledHeader>
+      <h1>
+        {organization} / {repos}{' '}
+      </h1>
+    </StyledHeader>
+  );
+};
+
+export default Header;

--- a/src/components/HomeButton.jsx
+++ b/src/components/HomeButton.jsx
@@ -1,0 +1,27 @@
+import { useNavigate } from 'react-router';
+import styled from 'styled-components';
+
+const StyledHomeButton = styled.button`
+  border: none;
+  outline: none;
+  width: 200px;
+  cursor: pointer;
+  height: 100px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgb(237, 237, 237);
+  font-weight: 900;
+  border-radius: 10px;
+  :hover {
+    background-color: rgb(230, 230, 230);
+  }
+`;
+
+const HomeButton = () => {
+  const navigate = useNavigate();
+
+  return <StyledHomeButton onClick={() => navigate('/')}>메인화면으로 돌아가기</StyledHomeButton>;
+};
+
+export default HomeButton;

--- a/src/components/IssueItem.jsx
+++ b/src/components/IssueItem.jsx
@@ -1,0 +1,63 @@
+import { useContext } from 'react';
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+import { IssueContext } from '../store/issueContext';
+
+const Container = styled.li`
+  list-style: none;
+  width: 100%;
+  padding: 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: default;
+  :hover {
+    ${props => (props.profileImageUrl ? '' : 'background-color: rgb(237, 237, 237);font-weight: 600; cursor: pointer;')}
+  }
+
+  margin-bottom: 20px;
+`;
+
+const Content = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+
+  column-gap: 20px;
+
+  margin-bottom: 10px;
+  :last-child {
+    margin-bottom: 0px;
+  }
+  height: 100%;
+`;
+
+const ProfileImage = styled.img`
+  width: 100px;
+  height: 100px;
+  border-radius: 100%;
+`;
+
+const IssueItem = ({ number, title, login, createdAt, commentCount, profileImageUrl }) => {
+  const href = `${number}`;
+  const { setIssue } = useContext(IssueContext);
+  return (
+    <Link to={href}>
+      <Container onClick={() => setIssue(number)} profileImageUrl={profileImageUrl}>
+        {profileImageUrl && <ProfileImage alt="profile" src={profileImageUrl} />}
+        <div>
+          <Content>
+            <div>#{number}</div>
+            <div>{title}</div>
+          </Content>
+          <Content>
+            <div>작성자 : {login}</div>
+            <div>작성일 : {createdAt}</div>
+          </Content>
+        </div>
+        <div>코멘트 : {commentCount}</div>
+      </Container>
+    </Link>
+  );
+};
+export default IssueItem;

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,0 +1,36 @@
+import styled, { keyframes } from 'styled-components';
+
+const scale = keyframes`
+    0%{
+            scale:0;
+        }
+        100%{
+            scale:2;
+        }
+`;
+
+const StyledLoading = styled.div`
+  width: 80px;
+  height: 80px;
+
+  border-radius: 100%;
+  background-color: black;
+
+  animation: ${scale} 1s infinite;
+`;
+
+const LoadingContainer = styled.div`
+  width: 100%;
+  height: 200px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Loading = () => (
+  <LoadingContainer>
+    <StyledLoading />
+  </LoadingContainer>
+);
+
+export default Loading;

--- a/src/components/RedirectToError.jsx
+++ b/src/components/RedirectToError.jsx
@@ -1,0 +1,11 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const RedirectToError = () => {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate('/error');
+  }, []);
+};
+
+export default RedirectToError;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const BASE_URL = 'https://api.github.com/';
+export const ACESS_TOKEN = import.meta.env.VITE_GITHUB_PERSONAL_TOKEN;

--- a/src/hooks/useIntersect.js
+++ b/src/hooks/useIntersect.js
@@ -1,0 +1,27 @@
+import { useEffect, useCallback, useRef } from 'react';
+//  옵션 값을 지정한다.
+const useIntersect = (onIntersect, options) => {
+  const ref = useRef(null);
+  const callback = useCallback(
+    (entries, observer) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) onIntersect(entry, observer);
+      });
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+
+    // eslint-disable-next-line consistent-return
+    return () => observer.disconnect();
+  }, [ref, options, callback]);
+
+  return ref;
+};
+
+export default useIntersect;

--- a/src/hooks/useIssue.js
+++ b/src/hooks/useIssue.js
@@ -1,0 +1,29 @@
+import { useContext, useEffect, useState } from 'react';
+import { fetchIssue } from '../apis/issues';
+import { HttpResultState } from '../store/httpResultContext';
+
+const useIssue = number => {
+  const [issue, setIssue] = useState({});
+  const { loading, setError, setLoading } = useContext(HttpResultState);
+
+  const getIssue = async number => {
+    setLoading(true);
+    const { issue, status, message } = await fetchIssue(number);
+
+    if (status >= 400) {
+      setError({ status, message });
+      return;
+    }
+
+    setIssue({ ...issue, issue });
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    getIssue(number);
+  }, []);
+
+  return { issue, loading, getIssue };
+};
+
+export default useIssue;

--- a/src/hooks/useIssues.js
+++ b/src/hooks/useIssues.js
@@ -1,0 +1,33 @@
+import { useContext, useEffect, useState } from 'react';
+import { fetchIssues } from '../apis/issues';
+import { HttpResultState } from '../store/httpResultContext';
+import usePage from './usePage';
+
+const useIssues = () => {
+  const [issues, setIssues] = useState([]);
+  const { hasNextPage, setNextPage, pageCount, increasePage } = usePage();
+  const { loading, setError, setLoading } = useContext(HttpResultState);
+
+  const getIssues = async () => {
+    setLoading(true);
+    increasePage();
+    const { issues, status, message } = await fetchIssues({ page: pageCount });
+    if (status >= 400) {
+      setError({ status, message });
+      return;
+    }
+    if (issues.length === 0) {
+      setNextPage(false);
+    }
+    setIssues(prevIssues => prevIssues.concat(issues));
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    getIssues();
+  }, []);
+
+  return { issues, getIssues, hasNextPage, loading, pageCount };
+};
+
+export default useIssues;

--- a/src/hooks/usePage.js
+++ b/src/hooks/usePage.js
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+const usePage = () => {
+  const [hasNextPage, setNextPage] = useState(true);
+  const [pageCount, setPageCount] = useState(0);
+
+  const increasePage = () => {
+    setPageCount(prev => prev + 1);
+  };
+
+  return { hasNextPage, setNextPage, pageCount, increasePage };
+};
+
+export default usePage;

--- a/src/hooks/useScroll.js
+++ b/src/hooks/useScroll.js
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from 'react';
+
+const useScroll = (callBack, target, pageNum, loading) => {
+  const copiedPageNum = pageNum;
+  const height = useRef(1);
+
+  useEffect(() => {
+    if (loading === 'initial') {
+      setTimeout(() => {
+        observer.observe(target.current);
+      }, 1000);
+    }
+  }, []);
+
+  const options = {
+    threshold: 1.0,
+  };
+
+  const changePage = () => {
+    copiedPageNum.current += 1;
+    height.current += 1;
+    callBack();
+  };
+
+  const observer = new IntersectionObserver(changePage, options);
+
+  return { height };
+};
+
+export default useScroll;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import GlobalStyle from './styles/GlobalStyle';
 import App from './App';
 
-
-ReactDOM.createRoot(document.getElementById('root')).render(
-  <React.StrictMode>
-    <GlobalStyle />
-    <App />
-  </React.StrictMode>
-);
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/src/pages/error.jsx
+++ b/src/pages/error.jsx
@@ -1,0 +1,32 @@
+import { useContext } from 'react';
+import styled from 'styled-components';
+import { HttpResultState } from '../store/httpResultContext';
+import HomeButton from '../components/HomeButton';
+
+const ErrorBox = styled.div`
+  height: 400px;
+  font-size: 30px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  h1 {
+    :nth-child(2) {
+      margin-bottom: 100px;
+    }
+  }
+`;
+
+const Error = () => {
+  const { error } = useContext(HttpResultState);
+  const { status, message } = error;
+  return (
+    <ErrorBox>
+      <h1>{status}</h1>
+      <h1>{message}</h1>
+      <HomeButton />
+    </ErrorBox>
+  );
+};
+
+export default Error;

--- a/src/pages/issue.jsx
+++ b/src/pages/issue.jsx
@@ -1,0 +1,36 @@
+import { useContext } from 'react';
+import { useParams } from 'react-router';
+import ReactMarkdown from 'react-markdown';
+import IssueItem from '../components/IssueItem';
+import Loading from '../components/Loading';
+import { IssueContext } from '../store/issueContext';
+import { HttpResultState } from '../store/httpResultContext';
+import RedirectToError from '../components/RedirectToError';
+
+const Issue = () => {
+  const { number } = useParams();
+  // const { issue, loading } = useIssue(number);
+  const { loading, error } = useContext(HttpResultState);
+  const { issue } = useContext(IssueContext);
+  const { title, login, createdAt, profileImageUrl, commentCount, body } = issue;
+
+  if (error) return <RedirectToError />;
+  return loading ? (
+    <Loading />
+  ) : (
+    <div>
+      <IssueItem
+        number={number}
+        title={title}
+        login={login}
+        createdAt={createdAt}
+        profileImageUrl={profileImageUrl}
+        commentCount={commentCount}
+      />
+      <ReactMarkdown>{body}</ReactMarkdown>
+      <div>{commentCount}</div>
+    </div>
+  );
+};
+
+export default Issue;

--- a/src/pages/issues.jsx
+++ b/src/pages/issues.jsx
@@ -1,0 +1,61 @@
+import { useContext } from 'react';
+import styled from 'styled-components';
+import IssueItem from '../components/IssueItem';
+import useIssues from '../hooks/useIssues';
+import useIntersect from '../hooks/useIntersect';
+import Loading from '../components/Loading';
+import Ad from '../components/Ad';
+import { HttpResultState } from '../store/httpResultContext';
+import RedirectToError from '../components/RedirectToError';
+
+const PageChangeBar = styled.div`
+  width: 100%;
+  height: 5px;
+`;
+
+const Divider = styled.div`
+  height: 1px;
+  margin-bottom: 20px;
+  background-color: gray;
+  :last-child {
+    display: none;
+  }
+`;
+const Issues = () => {
+  const { issues, getIssues, hasNextPage, loading, pageCount } = useIssues();
+  const { error } = useContext(HttpResultState);
+  const ref = useIntersect(async (entry, observer) => {
+    observer.unobserve(entry.target);
+    if (hasNextPage && !loading) {
+      getIssues();
+    }
+  });
+  const ad = index => index % 5 === 0;
+  if (error) return <RedirectToError RedirectToError />;
+  return (
+    <div style={{ height: `${pageCount.current * 100}vh` }}>
+      {issues.map(({ number, title, login, createdAt, commentCount }, index) => (
+        <>
+          <IssueItem
+            key={index}
+            number={number}
+            title={title}
+            login={login}
+            createdAt={createdAt}
+            commentCount={commentCount}
+          />
+          <Divider />
+          {ad(index + 1) && (
+            <Ad
+              imageUrl="https://blog.kakaocdn.net/dn/0aDVr/btrbQaX9WJr/p63pboivEKfeoYcIDKQYN1/img.jpg"
+              link="https://www.wanted.co.kr/jobsfeed"
+            />
+          )}
+        </>
+      ))}
+      {loading && <Loading />}
+      {!loading && <PageChangeBar ref={ref} />}
+    </div>
+  );
+};
+export default Issues;

--- a/src/store/httpResultContext.jsx
+++ b/src/store/httpResultContext.jsx
@@ -1,0 +1,29 @@
+import { createContext, useState } from 'react';
+
+export const HttpResultState = createContext({
+  loading: true || false,
+  error: {
+    status: null,
+    message: '',
+  },
+  setError: () => {},
+  setLoading: () => {},
+});
+
+const HttpResultStateProvider = ({ children }) => {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const contextValue = {
+    loading,
+    error,
+    setLoading: state => {
+      setLoading(state);
+    },
+    setError: error => setError({ ...error, error }),
+  };
+
+  return <HttpResultState.Provider value={contextValue}>{children}</HttpResultState.Provider>;
+};
+
+export default HttpResultStateProvider;

--- a/src/store/issueContext.jsx
+++ b/src/store/issueContext.jsx
@@ -1,0 +1,34 @@
+import { createContext, useContext, useState } from 'react';
+import { HttpResultState } from './httpResultContext';
+import { fetchIssue } from '../apis/issues';
+
+export const IssueContext = createContext({
+  issue: {},
+  setIssue: () => {},
+});
+
+const IssueContextProvider = ({ children }) => {
+  const [issue, setIssue] = useState('facebook');
+  const { setLoading, setError } = useContext(HttpResultState);
+
+  const setIssueHandler = async number => {
+    setLoading(true);
+    const { issue, status, message } = await fetchIssue(number);
+
+    if (status >= 400) {
+      setError({ status, message });
+      return;
+    }
+
+    setIssue({ ...issue, issue });
+    setLoading(false);
+  };
+  const contextValue = {
+    issue,
+    setIssue: number => setIssueHandler(number),
+  };
+
+  return <IssueContext.Provider value={contextValue}>{children}</IssueContext.Provider>;
+};
+
+export default IssueContextProvider;

--- a/src/store/reposContext.jsx
+++ b/src/store/reposContext.jsx
@@ -1,0 +1,28 @@
+import { createContext, useState } from 'react';
+
+export const ReposContext = createContext({
+  organization: '',
+  repos: '',
+  setOrganization: () => {},
+  setRepos: () => {},
+});
+
+const ReposContextProvider = ({ children }) => {
+  const [organization, setOrganization] = useState('facebook');
+  const [repos, setRepos] = useState('react');
+  const contextValue = {
+    organization,
+    repos,
+    setOrganization: issues => {
+      setOrganization(issues);
+    },
+
+    setRepos: repos => {
+      setRepos(repos);
+    },
+  };
+
+  return <ReposContext.Provider value={contextValue}>{children}</ReposContext.Provider>;
+};
+
+export default ReposContextProvider;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,5 +1,22 @@
 import { createGlobalStyle } from 'styled-components';
 
-const GlobalStyle = createGlobalStyle``;
+const GlobalStyle = createGlobalStyle`  
+   * {
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    margin: 0;
+    padding: 40px;
+  }
+
+  a{
+    color: black;
+    text-decoration: none;
+  }
+`;
 
 export default GlobalStyle;

--- a/src/utils/dateFormat.js
+++ b/src/utils/dateFormat.js
@@ -1,0 +1,6 @@
+const dateFormat = date => {
+  const newDate = `${new Date(date).getFullYear()}년 ${new Date(date).getMonth()}월 ${new Date(date).getDay()}일`;
+  return newDate;
+};
+
+export default dateFormat;

--- a/src/utils/handleErrorResult.js
+++ b/src/utils/handleErrorResult.js
@@ -1,0 +1,8 @@
+const handleErrorResult = e => {
+  const { data, status } = e.response;
+  const { message } = data;
+
+  return { status, message };
+};
+
+export default handleErrorResult;


### PR DESCRIPTION
_커밋을 분리시키지 않은 점 죄송합니다.. ㅠㅠ 작업을 짧은 시간내에 급박하게 하다보니 생겨난 일 같습니다. 다음 과제땐 신경쓰겠습니다._

## PR Type

- [x] FEAT: 새로운 기능 구현
- [ ] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [ ] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts

- 3주차 기업과제 1차 개인 구현 완료
- 
## Description

- 이슈 목록 및 상세 화면 기능 구현
- Context API를 활용한 API 연동
- 데이터 요청 중 로딩 표시
- 에러 화면 구현
- 지정된 조건(open 상태, 코멘트 많은 순)에 맞게 데이터 요청 및 표시

## Discussion

- 추후 함께 논의할 점에 대해 작성해주세요.

### 고민했던 부분

- API 호출 전에 loading state 를 true, 호출 추에 false 로 바꾸는 로직이 공통적으로 들어가서 custom hook 으로 구현 시도 했으나 불명확한 에러로 구현 못함
- 다수의 ContextProvider 를 묶어서 배열의 형태로 관리 [관련 링크](https://javascript.plainenglish.io/how-to-combine-context-providers-for-cleaner-react-code-9ed24f20225e)
---

Resolves #1
(작성한 Issue를 연결해주세요.)
