### PR TITLE
SUB3-루트 (/) url 이 아닌 url 로 접속시 에러 버그 수정

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
1. 접속 url 이 root 아닐 때 root 로 보내주는 옵션

## PR Type

- [ ] FEAT: 새로운 기능 구현
- [ ] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [ ] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [x] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts

- 루트 (/) url 이 아닌 이슈 넘버를 파라미터로 넘긴 url 로 접속시 404 에러 나는 버그 수정

## Description

- root/vercel.json 파일 추가 후 접속 url 이 root 아닐 때 root 로 보내주는 옵션 추가 


## Discussion

- 추후 함께 논의할 점에 대해 작성해주세요.

---

Resolves #1
(작성한 Issue를 연결해주세요.)
